### PR TITLE
Adds TMPro support to SelectionToggles.

### DIFF
--- a/Runtime/Scripts/UI/SelectionToggles/AbstractSelectionToggle.cs
+++ b/Runtime/Scripts/UI/SelectionToggles/AbstractSelectionToggle.cs
@@ -20,14 +20,14 @@ namespace CommonUtils.SelectionToggles {
 		/// <param name="labelText">Text to be shown in the toggle.</param>
 		/// <param name="onSelected">Callback to be executed when the toggle is selected.</param>
 		public void Init(ISelectionToggleConfiguration<TSelectionValue> configuration, Action<TSelectionValue> onSelected) {
-            SetLabelText(configuration);
+            SetLabelText(configuration.SelectionToggleText);
             toggle.onValueChanged.RemoveAllListeners();
 			toggle.onValueChanged.AddListener(val => {
 				if (val) onSelected(configuration.SelectionToggleValue);
 			});
 		}
 
-        protected abstract void SetLabelText(ISelectionToggleConfiguration<TSelectionValue> configuration);
+        protected abstract void SetLabelText(string text);
 
 		public void SetToggleGroup(ToggleGroup toggleGroup) => toggle.group = toggleGroup;
 

--- a/Runtime/Scripts/UI/SelectionToggles/AbstractSelectionToggle.cs
+++ b/Runtime/Scripts/UI/SelectionToggles/AbstractSelectionToggle.cs
@@ -10,7 +10,6 @@ namespace CommonUtils.SelectionToggles {
 	/// <typeparam name="TSelectionValue"></typeparam>
 	public abstract class AbstractSelectionToggle<TSelectionValue> : MonoBehaviour {
 #pragma warning disable 649
-		[SerializeField] private Text label;
 		[SerializeField] private Toggle toggle;
 #pragma warning restore 649
 
@@ -21,12 +20,14 @@ namespace CommonUtils.SelectionToggles {
 		/// <param name="labelText">Text to be shown in the toggle.</param>
 		/// <param name="onSelected">Callback to be executed when the toggle is selected.</param>
 		public void Init(ISelectionToggleConfiguration<TSelectionValue> configuration, Action<TSelectionValue> onSelected) {
-			label.text = configuration.SelectionToggleText;
-			toggle.onValueChanged.RemoveAllListeners();
+            SetLabelText(configuration);
+            toggle.onValueChanged.RemoveAllListeners();
 			toggle.onValueChanged.AddListener(val => {
 				if (val) onSelected(configuration.SelectionToggleValue);
 			});
 		}
+
+        protected abstract void SetLabelText(ISelectionToggleConfiguration<TSelectionValue> configuration);
 
 		public void SetToggleGroup(ToggleGroup toggleGroup) => toggle.group = toggleGroup;
 

--- a/Runtime/Scripts/UI/SelectionToggles/AbstractTMPSelectionToggle.cs
+++ b/Runtime/Scripts/UI/SelectionToggles/AbstractTMPSelectionToggle.cs
@@ -8,8 +8,8 @@ namespace CommonUtils.SelectionToggles {
 #pragma warning disable 649
         [SerializeField] private TextMeshProUGUI label;
 #pragma warning restore 649
-        protected override void SetLabelText(ISelectionToggleConfiguration<TSelectionValue> configuration) {
-            label.text = configuration.SelectionToggleText;
+        protected override void SetLabelText(string text) {
+            label.text = text;
         }
     }
 }

--- a/Runtime/Scripts/UI/SelectionToggles/AbstractTMPSelectionToggle.cs
+++ b/Runtime/Scripts/UI/SelectionToggles/AbstractTMPSelectionToggle.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using TMPro;
+
+namespace CommonUtils.SelectionToggles {
+    public abstract class AbstractTMPSelectionToggle<TSelectionValue> : AbstractSelectionToggle<TSelectionValue> {
+#pragma warning disable 649
+        [SerializeField] private TextMeshProUGUI label;
+#pragma warning restore 649
+        protected override void SetLabelText(ISelectionToggleConfiguration<TSelectionValue> configuration) {
+            label.text = configuration.SelectionToggleText;
+        }
+    }
+}

--- a/Runtime/Scripts/UI/SelectionToggles/AbstractTMPSelectionToggle.cs.meta
+++ b/Runtime/Scripts/UI/SelectionToggles/AbstractTMPSelectionToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf462d8770bb0924198252df0e4f7255
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/UI/SelectionToggles/AbstractUGUISelectionToggle.cs
+++ b/Runtime/Scripts/UI/SelectionToggles/AbstractUGUISelectionToggle.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+
+namespace CommonUtils.SelectionToggles {
+    public abstract class AbstractUGUISelectionToggle<TSelectionValue> : AbstractSelectionToggle<TSelectionValue> {
+#pragma warning disable 649
+        [SerializeField] private Text label;
+#pragma warning restore 649
+
+        protected override void SetLabelText(ISelectionToggleConfiguration<TSelectionValue> configuration) {
+            label.text = configuration.SelectionToggleText;
+        }
+    }
+}

--- a/Runtime/Scripts/UI/SelectionToggles/AbstractUGUISelectionToggle.cs
+++ b/Runtime/Scripts/UI/SelectionToggles/AbstractUGUISelectionToggle.cs
@@ -7,8 +7,8 @@ namespace CommonUtils.SelectionToggles {
         [SerializeField] private Text label;
 #pragma warning restore 649
 
-        protected override void SetLabelText(ISelectionToggleConfiguration<TSelectionValue> configuration) {
-            label.text = configuration.SelectionToggleText;
+        protected override void SetLabelText(string text) {
+            label.text = text;
         }
     }
 }

--- a/Runtime/Scripts/UI/SelectionToggles/AbstractUGUISelectionToggle.cs.meta
+++ b/Runtime/Scripts/UI/SelectionToggles/AbstractUGUISelectionToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5b961ef7c9b67640a18a470ce37909f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/UI/SelectionToggles/IntSelectionToggle.cs
+++ b/Runtime/Scripts/UI/SelectionToggles/IntSelectionToggle.cs
@@ -1,3 +1,3 @@
 namespace CommonUtils.SelectionToggles {
-	public class IntSelectionToggle : AbstractSelectionToggle<int> { }
+	public class IntSelectionToggle : AbstractUGUISelectionToggle<int> { }
 }

--- a/Runtime/Scripts/UI/SelectionToggles/StringSelectionToggle.cs
+++ b/Runtime/Scripts/UI/SelectionToggles/StringSelectionToggle.cs
@@ -1,3 +1,3 @@
 namespace CommonUtils.SelectionToggles {
-	public class StringSelectionToggle : AbstractSelectionToggle<string> { }
+	public class StringSelectionToggle : AbstractUGUISelectionToggle<string> { }
 }

--- a/Runtime/Scripts/UI/SelectionToggles/TMPIntSelectionToggle.cs
+++ b/Runtime/Scripts/UI/SelectionToggles/TMPIntSelectionToggle.cs
@@ -1,0 +1,3 @@
+﻿namespace CommonUtils.SelectionToggles {
+    public class TMPIntSelectionToggle : AbstractTMPSelectionToggle<int> { }
+}

--- a/Runtime/Scripts/UI/SelectionToggles/TMPIntSelectionToggle.cs.meta
+++ b/Runtime/Scripts/UI/SelectionToggles/TMPIntSelectionToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 210beb3716d7c79459c1b6269eccbcf8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/UI/SelectionToggles/TMPStringSelectionToggle.cs
+++ b/Runtime/Scripts/UI/SelectionToggles/TMPStringSelectionToggle.cs
@@ -1,0 +1,3 @@
+﻿namespace CommonUtils.SelectionToggles {
+    public class TMPStringSelectionToggle : AbstractTMPSelectionToggle<string> { }
+}

--- a/Runtime/Scripts/UI/SelectionToggles/TMPStringSelectionToggle.cs.meta
+++ b/Runtime/Scripts/UI/SelectionToggles/TMPStringSelectionToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0895087c21c82c148b7998c83242760c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/com.ecasillas.commonutils.asmdef
+++ b/Runtime/Scripts/com.ecasillas.commonutils.asmdef
@@ -1,7 +1,8 @@
 {
     "name": "com.ecasillas.commonutils",
     "references": [
-        "com.pixelplacement.itween"
+        "com.pixelplacement.itween",
+        "Unity.TextMeshPro"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],


### PR DESCRIPTION
### Breaking Change:
Breaks reference on AbstractSelectionToggle.cs label.

To support TMPro and UnityEngine.UI, label was removed, the Init method now calls the protected abstract method "SetLabelText".

Two child classes (one for Unity GUI and one for TMPro) are created: AbstractUGUISelectionToggle and abstractTMPSelectionToggle.

IntSelectionToggle and StringSelectionToggle now inherit from AbstractUGUISelectionToggle instead of AbstractSelectionToggle
Two new clases, TMPIntSelectionToggle and TMPStringSelectionToggle were created, inheriting from AbstractTMPSelectionToggle.