### PR TITLE
Fixes error CS0029 on UIKeyboardBindingsWindow.cs

### DIFF
--- a/Editor/UIKeyboardBindingsWindow.cs
+++ b/Editor/UIKeyboardBindingsWindow.cs
@@ -151,7 +151,7 @@ namespace CommonUtils.Editor {
 			if (context == null || bindings == null || unmappedButtons == null) return true;
 			var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
 
-			if (prefabStage) {
+			if (prefabStage != null) {
 				return (PrefabStage) context != prefabStage;
 			}
 

--- a/Editor/UIKeyboardBindingsWindow.cs
+++ b/Editor/UIKeyboardBindingsWindow.cs
@@ -150,10 +150,15 @@ namespace CommonUtils.Editor {
 		private static bool hasContextChanged() {
 			if (context == null || bindings == null || unmappedButtons == null) return true;
 			var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
-
-			if (prefabStage != null) {
+#if UNITY_2019_4_OR_NEWER
+			if (prefabStage!=null) {
 				return (PrefabStage) context != prefabStage;
 			}
+#else
+			if (prefabStage) {
+				return (PrefabStage) context != prefabStage;
+			}
+#endif
 
 			if (context is Scene contextScene) {
 				return contextScene != SceneManager.GetActiveScene();


### PR DESCRIPTION
Packages\CommonUtils\Editor\UIKeyboardBindingsWindow.cs(154,8): error CS0029: Cannot implicitly convert type 'UnityEditor.Experimental.SceneManagement.PrefabStage' to 'bool'

It seems like it was not implicitly converting PrefabStage to null.